### PR TITLE
Use built-in Node argument parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "bic": "./index.js"
   },
   "scripts": {
-    "bic": "node index.js"
+    "bic": "node index.js",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18.3"
   },
   "repository": {
     "type": "git",

--- a/parseArguments.js
+++ b/parseArguments.js
@@ -1,13 +1,20 @@
-export const parseArguments = (args) => {
-  const sourceIndex = args.indexOf("--source");
-  const destinationIndex = args.indexOf("--destination");
+import { parseArgs } from "node:util";
 
-  if (sourceIndex === -1 || destinationIndex === -1) {
+export const parseArguments = (args) => {
+  const { values } = parseArgs({
+    args,
+    options: {
+      "destination": { short: "d", type: "string" },
+      "source": { short: "s", type: "string" },
+    },
+  });
+
+  if (!values.destination || !values.source) {
     throw new Error("Please provide both --source and --destination arguments");
   }
 
   return {
-    sourceRepo: args[sourceIndex + 1],
-    destinationRepo: args[destinationIndex + 1],
+    sourceRepo: values.source,
+    destinationRepo: values.destination,
   };
 };

--- a/parseArguments.test.js
+++ b/parseArguments.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseArguments } from "./parseArguments.js";
+
+describe("parseArguments", () => {
+  [
+    [],
+    ["--source", "source/repo"],
+    ["--destination", "destination/repo"],
+  ].forEach((args) => {
+    it(`rejects missing arguments for ${JSON.stringify(args)}`, () => {
+      assert.throws(() => parseArguments(args));
+    });
+  });
+
+  it("exposes provided arguments", () => {
+    const destinationRepo = "destination/repo";
+    const sourceRepo = "source/repo";
+    assert.deepEqual(parseArguments([
+      "--source", sourceRepo,
+      "--destination", destinationRepo,
+    ]), { destinationRepo, sourceRepo });
+  });
+});


### PR DESCRIPTION
Uses [`parseArgs`](https://nodejs.org/docs/latest-v20.x/api/util.html#utilparseargsconfig) to parse command-line arguments.

**Pros**:

- Supports shorthand names (`-s`/`--source`, `-d`/`--destination`)
- Clearly handles edge cases (e.g. if you have `--source` _without_ a value after, you get _"Option '-s, --source <value>' argument missing"_ rather than the previous returning undefined)

**Cons**:

- Means only Node >=18.3 is supported (I added this explicitly to [`engines`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines))

I also added some tests for the parsing to ensure the core behaviour was retained.
